### PR TITLE
Amend installation/ description so that it does what it says

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 wkhtmltopdf
 ================
 
-This repository contains the static compiled binaries from the [wkhtmltopdf project](http://wkhtmltopdf.org/).
+This repository contains the static compiled 64-bit AMD binary from the [wkhtmltopdf project](http://wkhtmltopdf.org/).
 More about the functionality of wkhtmltopdf and wkthmltoimage can be found there.
 
 Binaries for __Microsoft Windows__, also installable with composer, can be found here: [github.com/wemersonjanuario/wkhtmltopdf-windows](https://github.com/wemersonjanuario/wkhtmltopdf-windows)
@@ -12,23 +12,19 @@ Binaries for __CentOS 7__, also installable with composer, can be found here: [g
 
 _Hint_:
 The version of the binary is equal to the git tag.
-To install the latest version, use '0.12.5'.
+To install the latest version, use: '0.12.6'.
 
 ### Packagist
 
 This package can be found on [Packagist](http://packagist.org) and installed with [Composer](https://getcomposer.org/).
 
-Require the package for _i386_ with:
+Require the package with:
 
-    php composer.phar require h4cc/wkhtmltopdf-i386 "0.12.5"
-
-And for _amd64_ with:
-
-    php composer.phar require h4cc/wkhtmltopdf-amd64 "0.12.5"
+    php composer.phar require olsgreen/wkhtmltopdf-amd64 "^0.12.6"
 
 The binary will then be located at:
 
-    vendor/h4cc/wkhtmltopdf-i386/bin/wkhtmltopdf-i386
+    vendor/olsgreen/wkhtmltopdf-amd64/bin/wkhtmltopdf-amd64
 
 Also a symlink will be created in your configured bin/ folder, for example:
 


### PR DESCRIPTION
Previous README had instructions for the forked h4cc project and - didn't work, either (`composer require h4cc/wkhtmltopdf-i386 "0.12.5"` - no such version at h4cc/wkhtmltopdf-i386).